### PR TITLE
chore: blacklist centos postgresql packages

### DIFF
--- a/tasks/install_yum.yml
+++ b/tasks/install_yum.yml
@@ -12,6 +12,15 @@
     name: "{{ postgresql_yum_repository_url }}"
     state: present
 
+- name: PostgreSQL | Blacklist CentOS PostgreSQL packages
+  replace: |
+    dest=/etc/yum.repos.d/CentOS-Base.repo \
+    regexp='^\[{{ item }}\]\n(?!exclude=postgresql*)' \
+    replace='[{{ item }}]\nexclude=postgresql*\n'
+  with_items:
+    - "base"
+    - "updates"
+
 - name: PostgreSQL | Make sure the dependencies are installed
   yum:
     name: "{{ item }}"


### PR DESCRIPTION
## Description

We don't want to use postgresql packages avalaible in the distribution repository, but only pgdg packages. Indeed the postgres documentation says :
```
Configure your YUM repository
Locate and edit your distributions .repo file, located:
On CentOS: /etc/yum.repos.d/CentOS-Base.repo, [base] and [updates] sections
To the section(s) identified above, you need to append a line (otherwise dependencies might resolve to the postgresql supplied by the base repository):
exclude=postgresql*
```