### PR TITLE
feat: handle 'always' archive mode in addition to 'on' and 'off'

### DIFF
--- a/templates/postgresql.conf-9.5.j2
+++ b/templates/postgresql.conf-9.5.j2
@@ -205,7 +205,7 @@ checkpoint_warning = {{postgresql_checkpoint_warning}}		# 0 disables
 
 # - Archiving -
 
-archive_mode = {{'on' if postgresql_archive_mode else 'off'}} # enables archiving; off, on, or always
+archive_mode = {{ postgresql_archive_mode }} # enables archiving; off, on, or always
 archive_command = '{{postgresql_archive_command}}'            # command to use to archive a logfile segment
 				# placeholders: %p = path of file to archive
 				#               %f = file name only


### PR DESCRIPTION
We need to have the possibility to use 'always' archive mode in addition to 'on' and 'off'.

For information, the archive_mode is set to off in [defaults/main.yml](https://github.com/lemonde/ansible-postgresql/blob/master/defaults/main.yml#L240)